### PR TITLE
[docs] Add Wayland clipboard support task

### DIFF
--- a/.codex/tasks/8b32df0a-wayland-clipboard-support.md
+++ b/.codex/tasks/8b32df0a-wayland-clipboard-support.md
@@ -1,0 +1,16 @@
+# Wayland clipboard support
+
+- **Role:** Coder
+
+## Summary
+CopyBuffer fails on CachyOS when running under Wayland because `pyperclip` cannot find a clipboard mechanism. Even with `xclip` and `xsel` installed, Wayland sessions require `wl-clipboard` (`wl-copy`/`wl-paste`).
+
+## Deliverables
+- Detect Wayland environments and attempt to use `wl-clipboard` when available.
+- Provide a helpful error message suggesting installation of `wl-clipboard` if no copy/paste mechanism is found.
+- Update documentation to mention `wl-clipboard` as a requirement for Wayland-based systems (e.g. CachyOS).
+
+## Acceptance checks
+- Running `cb` under Wayland with `wl-clipboard` installed successfully copies and pastes text.
+- Running under Wayland without `wl-clipboard` shows a clear install hint instead of an unhandled error.
+- `pytest` passes.


### PR DESCRIPTION
## Summary
- add CODER task to ensure copybuffer works under Wayland by leveraging wl-clipboard and better error messaging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c641309ab48321a7ef7a05b9fc77a8