### PR TITLE
[feat] Add Wayland clipboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2025-08-20
+### Added
+- Wayland clipboard support via `wl-clipboard` with improved dependency checks
+- Documentation updates for Wayland requirements
+
 ## [1.5.0] - 2024-03-20
 ### Added
 - STDIN support for piping content directly to clipboard

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A versatile command-line utility for copying file contents, directory contents, 
 - pyperclip
 - PIL (for image support)
 - xclip or xsel (Linux only)
+- wl-clipboard (Wayland only)
 
 ## Installation
 1. Install package with pipx:
@@ -36,6 +37,8 @@ pipx uninstall copybuffer)
 sudo apt-get install xclip
 # or
 sudo apt-get install xsel
+# For Wayland sessions
+sudo apt-get install wl-clipboard
 ```
 
 ## Usage
@@ -105,7 +108,7 @@ cb --debug filename.txt
 ```bash
 # Display version information
 cb --version
-# Output: copybuffer version 1.7.0
+# Output: copybuffer version 1.8.0
 ```
 
 ## Error Handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "copybuffer"
-version = "1.7.0"
+version = "1.8.0"
 description = "A command-line utility for copying file contents, directory contents, or STDIN input to the system clipboard."
 authors = [
     { name = "Draeician", email = "draeician@gmail.com" }
@@ -46,3 +46,4 @@ packages = ["copybuffer"]
 [project.scripts]
 cb = "copybuffer:main"  # Primary command
 "cb.py" = "copybuffer:main"  # Alias with .py extension
+

--- a/tests/test_wayland.py
+++ b/tests/test_wayland.py
@@ -1,0 +1,85 @@
+import pyperclip
+
+import copybuffer
+
+
+def test_is_wayland_detection(monkeypatch):
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    assert copybuffer.is_wayland()
+    monkeypatch.delenv("WAYLAND_DISPLAY")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+    assert copybuffer.is_wayland()
+    monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+    assert not copybuffer.is_wayland()
+
+
+def test_is_wlclipboard_installed(monkeypatch):
+    monkeypatch.setattr(copybuffer.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+    assert copybuffer.is_wlclipboard_installed()
+
+
+def test_check_dependencies_wayland_missing(monkeypatch):
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setattr(copybuffer, "is_wlclipboard_installed", lambda: False)
+    deps = copybuffer.check_dependencies()
+    assert "wl-clipboard (wl-copy and wl-paste)" in deps
+
+
+def test_check_dependencies_wayland_present(monkeypatch):
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setattr(copybuffer, "is_wlclipboard_installed", lambda: True)
+    deps = copybuffer.check_dependencies()
+    assert "wl-clipboard" not in "".join(deps)
+
+
+def test_check_dependencies_xclip_missing(monkeypatch):
+    monkeypatch.setattr(copybuffer, "is_wayland", lambda: False)
+    monkeypatch.setattr(copybuffer, "is_xclip_installed", lambda: False)
+    monkeypatch.setattr(copybuffer, "is_xsel_installed", lambda: False)
+    deps = copybuffer.check_dependencies()
+    assert deps == ["xclip or xsel"]
+
+
+def test_check_dependencies_missing_pyperclip(monkeypatch):
+    monkeypatch.setattr(copybuffer, "is_wayland", lambda: False)
+    monkeypatch.setattr(copybuffer, "is_xclip_installed", lambda: True)
+    monkeypatch.setattr(copybuffer, "is_xsel_installed", lambda: True)
+    monkeypatch.setattr(copybuffer, "is_pyperclip_installed", lambda: False)
+    deps = copybuffer.check_dependencies()
+    assert deps == ["pyperclip"]
+
+
+def test_copy_file_contents_success(monkeypatch):
+    captured = {}
+
+    def fake_copy(text):
+        captured["text"] = text
+
+    monkeypatch.setattr(pyperclip, "copy", fake_copy)
+    result = copybuffer.copy_file_contents_to_clipboard(
+        ["hello"],
+        include_header=True,
+        discord_attachment=True,
+        file_paths=["f.txt"],
+        debug=True,
+    )
+    assert captured["text"]
+    assert "=== File: f.txt ===" in captured["text"]
+    assert result
+
+
+def test_copy_file_contents_wayland_error(monkeypatch, capsys):
+    def raising_copy(_):
+        raise pyperclip.PyperclipException()
+
+    monkeypatch.setattr(pyperclip, "copy", raising_copy)
+    monkeypatch.setattr(copybuffer, "is_wayland", lambda: True)
+    copybuffer.copy_file_contents_to_clipboard(["data"])
+    assert "wl-clipboard" in capsys.readouterr().out
+
+
+def test_is_xclip_and_xsel_installed(monkeypatch):
+    monkeypatch.setattr(copybuffer.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+    assert copybuffer.is_xclip_installed()
+    assert copybuffer.is_xsel_installed()
+


### PR DESCRIPTION
## Summary
- detect Wayland sessions and prefer `wl-clipboard` when available
- document `wl-clipboard` requirement for Wayland users

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports .`
- `python -m pytest --cov=copybuffer --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_b_68c644ca83408321bb26fb3e6353681e