### PR TITLE
[feat] Expand Wayland detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ A versatile command-line utility for copying file contents, directory contents, 
 - xclip or xsel (Linux only)
 - wl-clipboard (Wayland only)
 
+  On CachyOS/Hyprland systems, `wl-clipboard` is required. Wayland detection
+  checks for `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE=wayland`,
+  `HYPRLAND_INSTANCE_SIGNATURE`, or `SWAYSOCK`.
+
 ## Installation
 1. Install package with pipx:
 ```bash

--- a/cb.py
+++ b/cb.py
@@ -12,9 +12,12 @@ __VERSION__ = "1.8.0"
 
 
 def is_wayland() -> bool:
+    """Return True if running in a Wayland session."""
     return bool(
         os.environ.get("WAYLAND_DISPLAY")
         or os.environ.get("XDG_SESSION_TYPE") == "wayland"
+        or os.environ.get("HYPRLAND_INSTANCE_SIGNATURE")
+        or os.environ.get("SWAYSOCK")
     )
 
 

--- a/copybuffer/__init__.py
+++ b/copybuffer/__init__.py
@@ -19,6 +19,8 @@ def is_wayland() -> bool:
     return bool(
         os.environ.get("WAYLAND_DISPLAY")
         or os.environ.get("XDG_SESSION_TYPE") == "wayland"
+        or os.environ.get("HYPRLAND_INSTANCE_SIGNATURE")
+        or os.environ.get("SWAYSOCK")
     )
 
 

--- a/tests/test_wayland.py
+++ b/tests/test_wayland.py
@@ -6,10 +6,20 @@ import copybuffer
 def test_is_wayland_detection(monkeypatch):
     monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
     assert copybuffer.is_wayland()
-    monkeypatch.delenv("WAYLAND_DISPLAY")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
     monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
     assert copybuffer.is_wayland()
     monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+
+    monkeypatch.setenv("HYPRLAND_INSTANCE_SIGNATURE", "1")
+    assert copybuffer.is_wayland()
+    monkeypatch.delenv("HYPRLAND_INSTANCE_SIGNATURE", raising=False)
+
+    monkeypatch.setenv("SWAYSOCK", "/run/user/1000/sway-ipc.sock")
+    assert copybuffer.is_wayland()
+    monkeypatch.delenv("SWAYSOCK", raising=False)
+
     assert not copybuffer.is_wayland()
 
 


### PR DESCRIPTION
## Summary
- expand Wayland detection to recognise HYPRLAND_INSTANCE_SIGNATURE and SWAYSOCK environment variables
- document wl-clipboard requirement for CachyOS/Hyprland and new Wayland detection variables

## Testing
- `PYTHONPATH=. pytest -q`

## Task
- `.codex/tasks/8b32df0a-wayland-clipboard-support.md`


------
https://chatgpt.com/codex/tasks/task_b_68c649a3430883219a521a6a32137934