### PR TITLE
feat: add image clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ cb --append path/to/file1.txt
 - `-a, --attachment`: Format output as Discord attachment
 - `-p, --paste`: Copy a heredoc shell script that recreates the given files when pasted
 - `--append`: Use with `--paste` behavior to append to files instead of overwriting
+- `--image`: Force treating input files as images (images are auto-detected)
 - `--debug`: Enable debug mode
 - `--version`: Display application version
 
 ### Image Support
-Supports copying image files directly to clipboard:
+Supports copying image files directly to clipboard. Image files are detected automatically
+based on their MIME type, or you can force image handling with the `--image` flag:
 - PNG
 - JPG/JPEG
 - BMP

--- a/cb.py
+++ b/cb.py
@@ -6,6 +6,10 @@ import os
 import shutil
 import sys
 
+import io
+import mimetypes
+import subprocess
+from PIL import Image
 import pyperclip
 
 __VERSION__ = "1.8.0"
@@ -100,6 +104,71 @@ def copy_file_contents_to_clipboard(
         print(f"Error: An unexpected error occurred. {str(e)}")
         return None
 
+
+def copy_image_to_clipboard(image_path):
+    """Copy an image file to the system clipboard as PNG."""
+    try:
+        img = Image.open(image_path)
+    except FileNotFoundError:
+        print(f"Error: File '{image_path}' not found")
+        return False
+    except Exception as e:
+        print(f"Error: Unable to open image '{image_path}': {e}")
+        return False
+
+    with io.BytesIO() as output:
+        img.save(output, format="PNG")
+        png_data = output.getvalue()
+
+    try:
+        if sys.platform.startswith("linux"):
+            if is_wayland() and shutil.which("wl-copy"):
+                subprocess.run(["wl-copy", "--type", "image/png"], input=png_data, check=True)
+            elif shutil.which("xclip"):
+                subprocess.run([
+                    "xclip",
+                    "-selection",
+                    "clipboard",
+                    "-t",
+                    "image/png",
+                ], input=png_data, check=True)
+            elif shutil.which("xsel"):
+                subprocess.run(
+                    ["xsel", "--clipboard", "--input", "--mime-type", "image/png"],
+                    input=png_data,
+                    check=True,
+                )
+            else:
+                print(
+                    "Error: No clipboard mechanism found. Install wl-clipboard, xclip, or xsel."
+                )
+                return False
+        elif sys.platform == "darwin":
+            subprocess.run(["pbcopy"], input=png_data, check=True)
+        elif sys.platform.startswith("win"):
+            try:
+                import win32clipboard
+                import win32con
+            except ImportError:
+                print("Error: win32clipboard module is required on Windows.")
+                return False
+
+            bmp = img.convert("RGB")
+            with io.BytesIO() as bmp_buffer:
+                bmp.save(bmp_buffer, "BMP")
+                dib_data = bmp_buffer.getvalue()[14:]
+            win32clipboard.OpenClipboard()
+            win32clipboard.EmptyClipboard()
+            win32clipboard.SetClipboardData(win32con.CF_DIB, dib_data)
+            win32clipboard.CloseClipboard()
+        else:
+            print("Error: Unsupported platform for image clipboard operations.")
+            return False
+    except Exception as e:
+        print(f"Error copying image to clipboard: {e}")
+        return False
+    return True
+
 def _choose_unique_heredoc_delimiter(contents: str) -> str:
     """Choose a heredoc delimiter that does not appear in contents.
 
@@ -187,6 +256,7 @@ def main():
     parser.add_argument("-a", "--attachment", action="store_true", help="Format output as Discord attachment")
     parser.add_argument("-p", "--paste", action="store_true", help="Format output as a shell heredoc script to create files on paste")
     parser.add_argument("--append", action="store_true", help="Like --paste, but append to the target files instead of overwriting")
+    parser.add_argument("--image", action="store_true", help="Force treating input files as images")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     args = parser.parse_args()
 
@@ -222,6 +292,13 @@ def main():
     file_contents_list = []
     valid_file_paths = []
     for file_path in args.files:
+        mime_type, _ = mimetypes.guess_type(file_path)
+        if args.debug:
+            print(f"Debug: MIME type for {file_path}: {mime_type}")
+        if args.image or (mime_type and mime_type.startswith("image/")):
+            if copy_image_to_clipboard(file_path):
+                print(f"Image '{file_path}' copied to clipboard successfully!")
+            continue
         try:
             with open(file_path, 'r') as file:
                 file_content = file.read().strip()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,48 @@
+from PIL import Image
+import copybuffer
+
+
+def create_temp_image(tmp_path):
+    img = Image.new("RGB", (1, 1), color="red")
+    path = tmp_path / "test.jpg"
+    img.save(path, format="JPEG")
+    return path
+
+
+def test_copy_image_wayland(monkeypatch, tmp_path):
+    path = create_temp_image(tmp_path)
+    captured = {}
+
+    def fake_run(cmd, input=None, check=None):
+        captured["cmd"] = cmd
+        captured["input"] = input
+
+    monkeypatch.setattr(copybuffer, "is_wayland", lambda: True)
+    monkeypatch.setattr(copybuffer.shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+    monkeypatch.setattr(copybuffer.subprocess, "run", fake_run)
+
+    assert copybuffer.copy_image_to_clipboard(str(path))
+    assert captured["cmd"][0] == "wl-copy"
+    assert captured["cmd"][1:] == ["--type", "image/png"]
+    assert captured["input"].startswith(b"\x89PNG")
+
+
+def test_copy_image_xclip(monkeypatch, tmp_path):
+    path = create_temp_image(tmp_path)
+    captured = {}
+
+    def fake_run(cmd, input=None, check=None):
+        captured["cmd"] = cmd
+        captured["input"] = input
+
+    def fake_which(cmd):
+        return "/usr/bin/xclip" if cmd == "xclip" else None
+
+    monkeypatch.setattr(copybuffer, "is_wayland", lambda: False)
+    monkeypatch.setattr(copybuffer.shutil, "which", fake_which)
+    monkeypatch.setattr(copybuffer.subprocess, "run", fake_run)
+
+    assert copybuffer.copy_image_to_clipboard(str(path))
+    assert captured["cmd"][:4] == ["xclip", "-selection", "clipboard", "-t"]
+    assert captured["cmd"][4] == "image/png"
+    assert captured["input"].startswith(b"\x89PNG")


### PR DESCRIPTION
## Summary
- detect image files and pipe them to the clipboard using Pillow with wl-copy/xclip/pbcopy/win32 clipboard backends
- add `--image` flag and automatic MIME detection in CLI
- document image support and provide tests for Wayland and X11 flows

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c78537682c8321937389fc817526a3