### PR TITLE
[docs] Add brainstorm mode guide and template

### DIFF
--- a/.codex/modes/BRAINSTORM.md
+++ b/.codex/modes/BRAINSTORM.md
@@ -1,0 +1,22 @@
+# Brainstorm Mode
+
+> This guide defines how Brainstormers ideate and explore solutions in the Aether Codex repo.
+
+## Purpose
+Brainstormers generate and organize ideas before implementation. They clarify problems, outline approaches, and surface unknowns to guide later roles.
+
+## Guidelines
+- Stay high-level; avoid committing to implementation details.
+- Capture diverse ideas and encourage creativity.
+- Ground suggestions in existing docs or code when relevant.
+- Note open questions or follow-up tasks.
+
+## Typical Actions
+- Restate the problem or prompt.
+- List possible directions with pros, cons, or risks.
+- Sketch rough diagrams, pseudocode, or mind maps.
+- Identify research needs or spikes for further exploration.
+
+## Communication
+Use status signals from `AGENTS.md` in task threads.
+Document conclusions or decision points concisely, favoring bullet lists over long narrative.

--- a/.codex/notes/BRAINSTORM_TEMPLATE.md
+++ b/.codex/notes/BRAINSTORM_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Brainstorm Session Template
+
+## Goal
+<What problem or opportunity are we exploring?>
+
+## Context
+<Background info, links, or constraints>
+
+## Ideas
+- <Idea 1>
+- <Idea 2>
+- <Idea 3>
+
+## Open Questions
+- <Question 1>
+- <Question 2>
+
+## Next Steps
+- <Action 1>
+- <Action 2>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Roles map to mode guides in `.codex/modes/`. Read your mode before starting.
 * Reviewer → `.codex/modes/REVIEWER.md`
 * Auditor → `.codex/modes/AUDITOR.md`
 * Blogger → `.codex/modes/BLOGGER.md`
+* Brainstorm → `.codex/modes/BRAINSTORM.md`
 * Swarm Manager → `.codex/modes/SWAMMANAGER.md`
 
 Tasks live in **`.codex/tasks/`** with random hash prefixes. Each task 


### PR DESCRIPTION
## Summary
- add Brainstorm mode guide for idea generation tasks
- register Brainstorm role in AGENTS
- provide brainstorming session template notes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c78eeaba8c8321b91c658c7daf2bb9