### PR TITLE
Add recursive directory discovery and gitignore support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A versatile command-line utility for copying file contents, directory contents, 
 ## Features
 - Copy text from files to clipboard
 - Copy text from STDIN to clipboard
-- Copy contents of all files in a directory
+- Copy contents of all files in a directory (non-recursive by default)
+- Recursively expand directories when needed
+- Honor `.gitignore` patterns while scanning directories
 - Copy images to clipboard
 - Include headers with filenames
 - Format output for Discord
@@ -55,8 +57,11 @@ cb filename.txt
 # Copy from STDIN
 echo "hello" | cb
 
-# Copy directory contents
+# Copy directory contents (non-recursive)
 cb -d directory/
+
+# Copy directory contents recursively
+cb -r directory/
 
 # Copy with Discord formatting
 cb -a filename.txt
@@ -74,12 +79,13 @@ cb --append path/to/file1.txt
 ### Options
 - `file`: File to copy (optional - reads from STDIN if not provided)
 - `-i, --include-header`: Include filename as header in copied text
-- `-d, --directory`: Copy contents of all files in directory
+- `-d, --directory`: Copy contents of all files in directory (non-recursive)
+- `-r, --recursive`: Recursively copy contents of provided directories
 - `-v, --verbose`: Display the copied contents
 - `-a, --attachment`: Format output as Discord attachment
 - `-p, --paste`: Copy a heredoc shell script that recreates the given files when pasted
 - `--append`: Use with `--paste` behavior to append to files instead of overwriting
-- `--image`: Force treating input files as images (images are auto-detected)
+- `--image`: Include image files discovered when expanding directories
 - `--debug`: Enable debug mode
 - `--version`: Display application version
 
@@ -101,8 +107,10 @@ Copy contents of all text files in a directory:
 cb -d /path/to/directory
 ```
 - Automatically skips image files
+- Uses `.gitignore` rules from the current working directory
 - Optionally includes headers with -i flag
 - Can format as Discord attachments with -a flag
+- Use `-r` to walk directories recursively and include nested files
 
 ### Debug Mode
 Enable detailed output for troubleshooting:

--- a/copybuffer/main.py
+++ b/copybuffer/main.py
@@ -1,9 +1,13 @@
 import argparse
 import mimetypes
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
 
 import pyperclip
 import tiktoken
+from pathspec import PathSpec
 
 from .core import (
     __VERSION__,
@@ -18,6 +22,168 @@ from .core import (
 )
 
 
+@dataclass
+class FileEntry:
+    abs_path: Path
+    display_path: str
+
+
+def _load_gitignore_spec(base_dir: Path) -> PathSpec | None:
+    gitignore_path = base_dir / ".gitignore"
+    if not gitignore_path.is_file():
+        return None
+    lines = gitignore_path.read_text().splitlines()
+    return PathSpec.from_lines("gitwildmatch", lines)
+
+
+def _is_ignored(path: Path, spec: PathSpec | None, base_dir: Path) -> bool:
+    if spec is None:
+        return False
+    try:
+        relative = path.resolve().relative_to(base_dir)
+    except ValueError:
+        relative = path.resolve()
+    return spec.match_file(str(relative))
+
+
+def _classify_path(
+    path: Path,
+    display_path: str,
+    allow_images: bool,
+) -> Tuple[List[FileEntry], List[FileEntry]]:
+    mime_type, _ = mimetypes.guess_type(str(path))
+    entry = FileEntry(abs_path=path, display_path=display_path)
+    if mime_type and mime_type.startswith("image/"):
+        if allow_images:
+            return [], [entry]
+        return [], []
+    return [entry], []
+
+
+def _discover_directory(
+    original_argument: str,
+    directory: Path,
+    recursive: bool,
+    allow_images: bool,
+    spec: PathSpec | None,
+    base_dir: Path,
+    debug: bool = False,
+) -> Tuple[List[FileEntry], List[FileEntry]]:
+    text_entries: List[FileEntry] = []
+    image_entries: List[FileEntry] = []
+    iterator: Iterable[Path]
+    if recursive:
+        iterator = directory.rglob("*")
+    else:
+        iterator = directory.iterdir()
+
+    for child in iterator:
+        if _is_ignored(child, spec, base_dir):
+            if debug:
+                print(f"Debug: Skipping ignored path {child}")
+            continue
+
+        try:
+            is_dir = child.is_dir()
+        except OSError:
+            continue
+
+        if is_dir:
+            # Skip directories; files within will be handled via rglob.
+            continue
+
+        if not child.is_file():
+            continue
+
+        try:
+            relative = child.relative_to(directory)
+            display_path = str(Path(original_argument) / relative)
+        except ValueError:
+            display_path = str(child)
+
+        text, images = _classify_path(child, display_path, allow_images)
+        text_entries.extend(text)
+        image_entries.extend(images)
+
+    text_entries.sort(key=lambda entry: entry.display_path)
+    image_entries.sort(key=lambda entry: entry.display_path)
+    return text_entries, image_entries
+
+
+def discover_files(
+    inputs: Sequence[str],
+    include_directory: bool,
+    recursive: bool,
+    allow_images: bool,
+    base_dir: Path | None = None,
+    debug: bool = False,
+) -> Tuple[List[FileEntry], List[FileEntry], List[str], List[str]]:
+    base_dir = (base_dir or Path.cwd()).resolve()
+    spec = _load_gitignore_spec(base_dir)
+
+    text_entries: List[FileEntry] = []
+    image_entries: List[FileEntry] = []
+    missing: List[str] = []
+    directory_errors: List[str] = []
+    seen: set[Path] = set()
+
+    for raw_path in inputs:
+        provided_path = Path(raw_path)
+        if provided_path.is_absolute():
+            candidate = provided_path.resolve()
+        else:
+            candidate = (base_dir / provided_path).resolve()
+
+        if not candidate.exists():
+            missing.append(raw_path)
+            continue
+
+        if candidate.is_dir():
+            if not include_directory and not recursive:
+                directory_errors.append(raw_path)
+                continue
+            dir_text, dir_images = _discover_directory(
+                raw_path,
+                candidate,
+                recursive,
+                allow_images,
+                spec,
+                base_dir,
+                debug,
+            )
+            for entry in dir_text:
+                if entry.abs_path in seen:
+                    continue
+                seen.add(entry.abs_path)
+                text_entries.append(entry)
+            for entry in dir_images:
+                if entry.abs_path in seen:
+                    continue
+                seen.add(entry.abs_path)
+                image_entries.append(entry)
+            continue
+
+        if _is_ignored(candidate, spec, base_dir):
+            if debug:
+                print(f"Debug: Skipping ignored path {candidate}")
+            continue
+
+        try:
+            display_path = str(candidate.relative_to(base_dir))
+        except ValueError:
+            display_path = raw_path
+
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+
+        text, images = _classify_path(candidate, display_path, True)
+        text_entries.extend(text)
+        image_entries.extend(images)
+
+    return text_entries, image_entries, missing, directory_errors
+
+
 def main():  # pragma: no cover
     parser = argparse.ArgumentParser(
         description="Copy file contents, images, or STDIN input to clipboard."
@@ -30,7 +196,16 @@ def main():  # pragma: no cover
         "-i", "--include-header", action="store_true", help="Include the filename as a header in copied text"
     )
     parser.add_argument(
-        "-d", "--directory", action="store_true", help="Copy contents of all files in directory"
+        "-d",
+        "--directory",
+        action="store_true",
+        help="Copy contents of all files in provided directories (non-recursive)",
+    )
+    parser.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Recursively copy contents of provided directories",
     )
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Display the copied contents"
@@ -53,7 +228,7 @@ def main():  # pragma: no cover
         "-t", "--tokens", action="store_true", help="Display token statistics for the file"
     )
     parser.add_argument(
-        "--image", action="store_true", help="Force treating input files as images"
+        "--image", action="store_true", help="Include image files discovered in directories"
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     args = parser.parse_args()
@@ -88,30 +263,43 @@ def main():  # pragma: no cover
                 print("Copied contents:\n" + combined_contents)
         return
 
-    # Process files
-    file_contents_list = []
-    valid_file_paths = []
-    for file_path in args.files:
-        mime_type, _ = mimetypes.guess_type(file_path)
-        if args.debug:
-            print(f"Debug: MIME type for {file_path}: {mime_type}")
-        if args.image or (mime_type and mime_type.startswith("image/")):
-            if copy_image_to_clipboard(file_path):
-                print(f"Image '{file_path}' copied to clipboard successfully!")
-            continue
+    text_entries, image_entries, missing, directory_errors = discover_files(
+        args.files, args.directory, args.recursive, args.image, debug=args.debug
+    )
+
+    for missing_path in missing:
+        print(f"Error: File '{missing_path}' not found")
+
+    for directory_path in directory_errors:
+        print(
+            f"Error: Directory '{directory_path}' requires --directory (-d) or --recursive (-r)."
+        )
+
+    file_contents_list: List[str] = []
+    valid_file_paths: List[str] = []
+    for entry in text_entries:
         try:
-            with open(file_path, "r") as file:
+            with entry.abs_path.open("r") as file:
                 file_content = file.read().strip()
-                file_contents_list.append(file_content)
-                valid_file_paths.append(file_path)
-                if args.debug:
-                    print(f"Debug: Read file {file_path}")
         except FileNotFoundError:
-            print(f"Error: File '{file_path}' not found")
+            print(f"Error: File '{entry.display_path}' not found")
             continue
         except Exception as e:
-            print(f"Error reading {file_path}: {e}")
+            print(f"Error reading {entry.display_path}: {e}")
             continue
+
+        file_contents_list.append(file_content)
+        valid_file_paths.append(entry.display_path)
+        if args.debug:
+            print(f"Debug: Read file {entry.abs_path}")
+
+    for image_entry in image_entries:
+        if args.debug:
+            print(f"Debug: Processing image {image_entry.abs_path}")
+        if copy_image_to_clipboard(str(image_entry.abs_path)):
+            print(
+                f"Image '{image_entry.display_path}' copied to clipboard successfully!"
+            )
 
     if file_contents_list:
         if args.paste or args.append:
@@ -138,26 +326,29 @@ def main():  # pragma: no cover
                 if args.verbose:
                     print("Copied contents:\n" + combined_contents)
 
+    all_entries = text_entries + image_entries
     if args.tokens:
+        if not all_entries:
+            return
         enc = tiktoken.get_encoding(encoding)
-        for file_path in args.files:
+        for entry in all_entries:
             try:
-                stats = get_file_stats(file_path)
+                stats = get_file_stats(str(entry.abs_path))
                 token_count = None
 
                 if not stats["is_binary"]:
-                    with open(file_path, "r") as file:
+                    with entry.abs_path.open("r") as file:
                         content = file.read()
                         tokens = enc.encode(content)
                         token_count = len(tokens)
 
-                print(format_file_stats(file_path, stats, token_count))
+                print(format_file_stats(entry.display_path, stats, token_count))
 
             except FileNotFoundError:
-                print(f"Error: File '{file_path}' not found")
+                print(f"Error: File '{entry.display_path}' not found")
             except Exception as e:
-                print(f"Error processing {file_path}: {e}")
+                print(f"Error processing {entry.display_path}: {e}")
         return
 
 
-__all__ = ["main"]
+__all__ = ["main", "discover_files"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ classifiers = [
 dependencies = [
     "pyperclip",
     "Pillow",
-    "tiktoken"
+    "tiktoken",
+    "pathspec"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyperclip
 pillow
 tiktoken
+pathspec

--- a/tests/test_discover_files.py
+++ b/tests/test_discover_files.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from copybuffer.main import discover_files
+
+
+def _as_relative_paths(entries):
+    return [entry.display_path for entry in entries]
+
+
+def test_discover_files_recursive_expands_nested(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    base = Path("project")
+    nested_dir = base / "nested" / "deeper"
+    (tmp_path / base).mkdir()
+    (tmp_path / nested_dir).mkdir(parents=True)
+    (tmp_path / base / "top.txt").write_text("root")
+    (tmp_path / nested_dir / "inner.txt").write_text("deep")
+
+    text_entries, image_entries, missing, directory_errors = discover_files(
+        [str(base)], include_directory=False, recursive=True, allow_images=False
+    )
+
+    assert missing == []
+    assert directory_errors == []
+    assert _as_relative_paths(text_entries) == [
+        "project/nested/deeper/inner.txt",
+        "project/top.txt",
+    ]
+    assert image_entries == []
+
+
+def test_discover_files_honors_gitignore_and_images(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".gitignore").write_text("ignored_dir/\n*.bin\n")
+
+    target_dir = Path("data")
+    ignored = target_dir / "ignored_dir"
+    (tmp_path / ignored).mkdir(parents=True)
+    (tmp_path / target_dir).mkdir(exist_ok=True)
+    (tmp_path / target_dir / "kept.txt").write_text("keep")
+    (tmp_path / ignored / "skip.txt").write_text("skip")
+    (tmp_path / target_dir / "artifact.bin").write_text("binary")
+    (tmp_path / target_dir / "picture.png").write_text("fake image")
+
+    text_entries, image_entries, missing, directory_errors = discover_files(
+        [str(target_dir)], include_directory=True, recursive=True, allow_images=False
+    )
+
+    assert missing == []
+    assert directory_errors == []
+    assert _as_relative_paths(text_entries) == ["data/kept.txt"]
+    assert image_entries == []
+
+    text_entries, image_entries, _, _ = discover_files(
+        [str(target_dir)], include_directory=True, recursive=True, allow_images=True
+    )
+
+    assert _as_relative_paths(text_entries) == ["data/kept.txt"]
+    assert _as_relative_paths(image_entries) == ["data/picture.png"]

--- a/tests/test_heredoc.py
+++ b/tests/test_heredoc.py
@@ -37,11 +37,13 @@ def test_generate_heredoc_script(tmp_path, append):
         "file1.txt",
         "dir with space/file2.txt",
         "weird 'quote'/file3.txt",
+        "nested/deeper/path/file4.txt",
     ]
     contents = [
         "alpha",
         "beta with $dollar and `backticks`",
         "gamma\nmulti-line\ncontent",
+        "delta\nwith nested dirs",
     ]
 
     if append:
@@ -56,6 +58,7 @@ def test_generate_heredoc_script(tmp_path, append):
     assert f"cat {redir} 'file1.txt'" in script_text
     assert _shell_single_quote("dir with space/file2.txt") in script_text
     assert _shell_single_quote("weird 'quote'/file3.txt") in script_text
+    assert _shell_single_quote("nested/deeper/path/file4.txt") in script_text
 
     delims = re.findall(r"<< '([^']+)'", script_text)
     assert len(delims) == len(file_paths)


### PR DESCRIPTION
## Summary
- add a directory discovery helper that honors .gitignore patterns and feeds the CLI expanded file lists
- introduce a --recursive flag, update directory handling to skip unsupported files, and ensure heredoc/tokens work with nested paths
- document the new switches and add regression tests for recursive scanning and heredoc generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e3c675094c8321ba7c1b5938dcbc14